### PR TITLE
Remove unneeded cast

### DIFF
--- a/cmd/function-sidecar_test.go
+++ b/cmd/function-sidecar_test.go
@@ -99,7 +99,7 @@ func TestIntegrationWithKafka(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			reply := string(msg.Payload.([]byte))
+			reply := string(msg.Payload)
 			if reply != expectedReply {
 				t.Fatal(fmt.Errorf("Received reply [%s] does not match expected reply [%s]", reply, expectedReply))
 			}


### PR DESCRIPTION
Fixes `cmd/function-sidecar_test.go:102:31: invalid type assertion: msg.Payload.([]byte) (non-interface type []byte on left)`